### PR TITLE
Fix port driver link method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+sudo: false # a requirement to get the dockerized builds
 language: erlang
-notifications:
-  webhooks: http://basho-engbot.herokuapp.com/travis?key=9b0dc343d8addd889d7a8d64c9b8b48dd22370aa
-  email: eng@basho.com
-otp_release:
-  - R15B01
-  - R15B
-  - R14B04
-  - R14B03
+otp_release: 17.5
+addons:
+  apt:
+    packages:
+    - zip
+script:
+  - make
+  - make test

--- a/c_src/spidermonkey.c
+++ b/c_src/spidermonkey.c
@@ -134,7 +134,7 @@ JSBool js_log(JSContext *cx, uintN argc, jsval *vp) {
     JS_free(cx, filename);
     JS_free(cx, output);
   }
-  return JSVAL_TRUE;
+  return JS_TRUE;
 }
 
 void sm_configure_locale(void) {

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,8 @@
 
 {port_env, [
              {"DRV_CFLAGS", "$DRV_CFLAGS -I c_src/system/include/js -DXP_UNIX -Wall"},
-             {"DRV_LDFLAGS", "$DRV_LDFLAGS $ERL_LDFLAGS -lstdc++ c_src/system/lib/libjs.a c_src/system/lib/libnspr4.a"},
+             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/system/lib/libjs.a c_src/system/lib/libnspr4.a"},
+             {"DRV_LINK_TEMPLATE", "$CXX $PORT_IN_FILES $LDFLAGS $DRV_LDFLAGS -o $PORT_OUT_FILE"},
 
              %% Define flags for enabling/disable 64 bit build of NSPR
              {"-32$", "NSPR_SIXTYFOUR", "--disable-64bit"},


### PR DESCRIPTION
The port driver was being build incorrectly on Travis and it failed to load with a `undefined symbol: __cxa_pure_virtual` error.

When linking C++ code, it is not always enough to just add libstdc++ to the linker input, the correct way is to use the C++ compiler driver program (`c++` instead of `cc`) because it does more stuff than that, some of it being platform dependent.
